### PR TITLE
Fix month index when converting Date to java.util.Date

### DIFF
--- a/src/main/java/net/sf/marineapi/nmea/util/Date.java
+++ b/src/main/java/net/sf/marineapi/nmea/util/Date.java
@@ -238,7 +238,7 @@ public class Date {
 	public java.util.Date toDate() {
 		GregorianCalendar cal = new GregorianCalendar();
 		cal.set(Calendar.YEAR, getYear());
-		cal.set(Calendar.MONTH, getMonth());
+		cal.set(Calendar.MONTH, getMonth() - 1);
 		cal.set(Calendar.DAY_OF_MONTH, getDay());
 		cal.set(Calendar.HOUR_OF_DAY, 0);
 		cal.set(Calendar.MINUTE, 0);

--- a/src/test/java/net/sf/marineapi/nmea/parser/ZDATest.java
+++ b/src/test/java/net/sf/marineapi/nmea/parser/ZDATest.java
@@ -181,7 +181,7 @@ public class ZDATest {
 
 		GregorianCalendar cal = new GregorianCalendar();
 		cal.set(Calendar.YEAR, 2010);
-		cal.set(Calendar.MONTH, 6);
+		cal.set(Calendar.MONTH, 5);
 		cal.set(Calendar.DAY_OF_MONTH, 15);
 		cal.set(Calendar.HOUR_OF_DAY, 12);
 		cal.set(Calendar.MINUTE, 15);


### PR DESCRIPTION
In **toDate** method of **net.sf.marineapi.nmea.util.Date** class the wrong index of month is being used. It must be 0 based - [link to Oracle docs.](http://docs.oracle.com/javase/8/docs/api/java/util/Calendar.html#MONTH)
In constructor month value is incremented but not decremented when converting back.