### PR TITLE
New TalkerID: VM

### DIFF
--- a/src/main/java/net/sf/marineapi/nmea/sentence/TalkerId.java
+++ b/src/main/java/net/sf/marineapi/nmea/sentence/TalkerId.java
@@ -124,6 +124,8 @@ public enum TalkerId {
 	TR,
 	/** Velocity Sensor, Doppler, other/general */
 	VD,
+	/** Velocity Sensor, Speed Log, Water, Magnetic */
+	VM,
 	/** Velocity Sensor, Speed Log, Water, Mechanical */
 	VW,
 	/** Weather Instruments */


### PR DESCRIPTION
Added new TalkerID - VM used by Velocity Sensor, Speed Log, Water, Magnetic.

In [some NMEA documentation](http://www.catb.org/gpsd/NMEA.html#_talker_ids) talker DM is listed between VD and VM. I guess this is typo and it should be VM.

From experience i can tell that some equipment uses VM instead DM.