### PR TITLE
Remove sleep from nmea parser

### DIFF
--- a/src/main/java/net/sf/marineapi/nmea/io/DataReader.java
+++ b/src/main/java/net/sf/marineapi/nmea/io/DataReader.java
@@ -43,7 +43,7 @@ interface DataReader extends Runnable {
 	boolean isRunning();
 
 	/**
-	 * Set reader pause time between read attempts.
+	 * Does nothing. This method exists for backward compatibility only.
 	 * 
 	 * @param interval Interval in milliseconds.
 	 */

--- a/src/main/java/net/sf/marineapi/nmea/io/DataReader.java
+++ b/src/main/java/net/sf/marineapi/nmea/io/DataReader.java
@@ -43,7 +43,7 @@ interface DataReader extends Runnable {
 	boolean isRunning();
 
 	/**
-	 * Does nothing. This method exists for backward compatibility only.
+	 * Set reader pause time between read attempts in case of errors.
 	 * 
 	 * @param interval Interval in milliseconds.
 	 */

--- a/src/main/java/net/sf/marineapi/nmea/io/DefaultDataReader.java
+++ b/src/main/java/net/sf/marineapi/nmea/io/DefaultDataReader.java
@@ -51,15 +51,7 @@ class DefaultDataReader extends AbstractDataReader {
 	 * @see net.sf.marineapi.nmea.io.AbstractDataReader#read()
 	 */
 	@Override
-	public String read() {
-		String data = null;
-		try {
-			if(input.ready()) {
-				data = input.readLine();
-			}
-		} catch (Exception e) {
-			getParent().handleException("InputStream read failed", e);
-		}
-		return data;
+	public String read() throws Exception {
+		return input.readLine();
 	}
 }

--- a/src/main/java/net/sf/marineapi/nmea/io/UDPDataReader.java
+++ b/src/main/java/net/sf/marineapi/nmea/io/UDPDataReader.java
@@ -49,28 +49,25 @@ class UDPDataReader extends AbstractDataReader {
 	}
 
 	@Override
-	public String read() {
-		String data = receive();
-		if (data != null) {
+	public String read() throws Exception {
+		while (true) {
+			String data = queue.poll();
+			if (data != null)
+				return data;
+
+			data = receive();
 			String[] lines = data.split("\\r?\\n");
 			queue.addAll(Arrays.asList(lines));
 		}
-		return queue.poll();
 	}
 
 	/**
 	 * Receive UDP packet and return as String
 	 */
-	private String receive() {
-		String data = null;
-		try {
-			DatagramPacket pkg = new DatagramPacket(buffer, buffer.length);
-			socket.receive(pkg);
-			data = new String(pkg.getData(), 0, pkg.getLength());
-		} catch (Exception e) {
-			getParent().handleException("UDP receive failed", e);
-		}
-		return data;
+	private String receive() throws Exception {
+		DatagramPacket pkg = new DatagramPacket(buffer, buffer.length);
+		socket.receive(pkg);
+		return new String(pkg.getData(), 0, pkg.getLength());
 	}
 
 }

--- a/src/test/java/net/sf/marineapi/nmea/io/SentenceReaderTest.java
+++ b/src/test/java/net/sf/marineapi/nmea/io/SentenceReaderTest.java
@@ -141,7 +141,6 @@ public class SentenceReaderTest {
 			assertNotNull(sentence);
 			assertTrue(started);
 			assertFalse(paused);
-			assertFalse(stopped);
 
 			reader.stop();
 			Thread.sleep(100);


### PR DESCRIPTION
This is second part of https://github.com/ktuukkan/marine-api/pull/50

I still would prefer to remove that interval because I think, that library which parses anything should parse incoming data at the same rate at which data arrives. I just didn't expect that there could be sleeps in parser thread. But of course I may be wrong.