### PR TITLE
Avoid sleeping when no parser is found

### DIFF
--- a/src/main/java/net/sf/marineapi/nmea/io/AbstractDataReader.java
+++ b/src/main/java/net/sf/marineapi/nmea/io/AbstractDataReader.java
@@ -21,8 +21,11 @@
 package net.sf.marineapi.nmea.io;
 
 import net.sf.marineapi.nmea.parser.SentenceFactory;
+import net.sf.marineapi.nmea.parser.UnsupportedSentenceException;
 import net.sf.marineapi.nmea.sentence.Sentence;
 import net.sf.marineapi.nmea.sentence.SentenceValidator;
+
+import java.util.logging.Logger;
 
 /**
  * Base class for data readers; common methods and run-loop.
@@ -33,6 +36,7 @@ abstract class AbstractDataReader implements DataReader {
 
 	// Sleep time between failed read attempts to prevent busy-looping
 	private static final int SLEEP_TIME = 100;
+	private static final Logger LOGGER = Logger.getLogger(AbstractDataReader.class.getName());
 
 	private final SentenceReader parent;
 	private volatile boolean isRunning = true;
@@ -91,8 +95,8 @@ abstract class AbstractDataReader implements DataReader {
 				} else if (!SentenceValidator.isSentence(data)) {
 					parent.fireDataEvent(data);
 				}
-			} catch (IllegalArgumentException iae) {
-				parent.handleException("No registered parser", iae);
+			} catch (UnsupportedSentenceException use) {
+				LOGGER.warning(use.getMessage());
 			} catch (Exception e) {
 				parent.handleException("Data read failed", e);
 				try {

--- a/src/main/java/net/sf/marineapi/nmea/io/AbstractDataReader.java
+++ b/src/main/java/net/sf/marineapi/nmea/io/AbstractDataReader.java
@@ -91,6 +91,8 @@ abstract class AbstractDataReader implements DataReader {
 				} else if (!SentenceValidator.isSentence(data)) {
 					parent.fireDataEvent(data);
 				}
+			} catch (IllegalArgumentException iae) {
+				parent.handleException("No registered parser", iae);
 			} catch (Exception e) {
 				parent.handleException("Data read failed", e);
 				try {

--- a/src/main/java/net/sf/marineapi/nmea/parser/SentenceFactory.java
+++ b/src/main/java/net/sf/marineapi/nmea/parser/SentenceFactory.java
@@ -215,7 +215,7 @@ public final class SentenceFactory {
 
 		if (!hasParser(sid)) {
 			String msg = String.format("Parser for type '%s' not found", sid);
-			throw new IllegalArgumentException(msg);
+			throw new UnsupportedSentenceException(msg);
 		}
 
 		Sentence parser = null;

--- a/src/main/java/net/sf/marineapi/nmea/parser/UnsupportedSentenceException.java
+++ b/src/main/java/net/sf/marineapi/nmea/parser/UnsupportedSentenceException.java
@@ -1,0 +1,18 @@
+package net.sf.marineapi.nmea.parser;
+
+/**
+ * Thrown when an unsupported sentence is encountered.
+ */
+public class UnsupportedSentenceException extends RuntimeException {
+
+    private static final long serialVersionUID = 7618916517933110942L;
+
+    /**
+     * Constructor
+     *
+     * @param msg Exception message
+     */
+    public UnsupportedSentenceException(String msg) {
+        super(msg);
+    }
+}

--- a/src/test/java/net/sf/marineapi/nmea/parser/SentenceFactoryTest.java
+++ b/src/test/java/net/sf/marineapi/nmea/parser/SentenceFactoryTest.java
@@ -206,7 +206,7 @@ public class SentenceFactoryTest {
 		try {
 			instance.createParser("$GPXYZ,1,2,3,4,5,6,7,8");
 			fail("Did not throw exception");
-		} catch (IllegalArgumentException e) {
+		} catch (UnsupportedSentenceException e) {
 			// pass
 		}
 	}


### PR DESCRIPTION
If no parser is found for a given sentence, it looks like the reader sleeps for a while:

https://github.com/ktuukkan/marine-api/blob/f3f998b9b26787a76c11ef719d7c4254f117b551/src/main/java/net/sf/marineapi/nmea/io/AbstractDataReader.java#L97

So, parsing a source that contains both known and unknown sentence types will make the parser very slow. This PR makes the parser proceed immediately if an unknown sentence is encountered. For other than `IllegalArgumentException`s, the sleep functionality remains in place.