### PR TITLE
Resetting the SentenceFactory instance for later tests

### DIFF
--- a/src/test/java/net/sf/marineapi/nmea/parser/SentenceFactoryTest.java
+++ b/src/test/java/net/sf/marineapi/nmea/parser/SentenceFactoryTest.java
@@ -17,6 +17,7 @@ import net.sf.marineapi.test.util.FOOParser;
 import net.sf.marineapi.test.util.FOOSentence;
 import net.sf.marineapi.test.util.VDMParser;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,6 +33,11 @@ public class SentenceFactoryTest {
 	 */
 	@Before
 	public void setUp() throws Exception {
+		instance.reset();
+	}
+
+	@After
+	public void tearDown() throws Exception {
 		instance.reset();
 	}
 
@@ -233,7 +239,6 @@ public class SentenceFactoryTest {
 		assertTrue(s instanceof VDMParser);
 		instance.unregisterParser(VDMParser.class);
 		assertFalse(instance.hasParser("VDM"));
-		instance.reset();
 	}
 
 	/**

--- a/src/test/java/net/sf/marineapi/nmea/parser/SentenceFactoryTest.java
+++ b/src/test/java/net/sf/marineapi/nmea/parser/SentenceFactoryTest.java
@@ -233,6 +233,7 @@ public class SentenceFactoryTest {
 		assertTrue(s instanceof VDMParser);
 		instance.unregisterParser(VDMParser.class);
 		assertFalse(instance.hasParser("VDM"));
+		instance.reset();
 	}
 
 	/**


### PR DESCRIPTION
When test `SentenceFactoryTest.testRegisterParserWithAlternativeBeginChar()` runs right before other tests such as those in `AbstractAISMessageListenerTest`, the tests that run afterwards fail. This test `testRegisterParserWithAlternativeBeginChar()` unregisters `VDMParser`, which is needed in other tests. The proposed pull request calls reset at the end of `testRegisterParserWithAlternativeBeginChar()` to register the parser again.

Please let me know if you want to discuss the changes more.