### PR TITLE
Added TLB, OSD, and RSD sentences and parsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 target/
 *.iml
 .gradle
+.vscode/

--- a/README.md
+++ b/README.md
@@ -6,21 +6,29 @@
 [![Javadocs](http://www.javadoc.io/badge/net.sf.marineapi/marineapi.svg)](http://www.javadoc.io/doc/net.sf.marineapi/marineapi)
 [![Sponsored by Spice](https://img.shields.io/badge/sponsored%20by-Spice-brightgreen.svg)](http://www.spiceprogram.org)
 
-- [About](#about)
+- [Java Marine API](#java-marine-api)
+  - [About](#about)
     - [Features](#features)
-- [Licensing](#licensing)
-- [Disclaimer](#disclaimer)
-- [Requirements](#requirements)
-- [Usage](#usage)
-- [Supported Protocols](#supported-protocols)
+    - [Licensing](#licensing)
+    - [Disclaimer](#disclaimer)
+    - [Requirements](#requirements)
+    - [Usage](#usage)
+  - [Supported Protocols](#supported-protocols)
     - [NMEA 0183](#nmea-0183)
     - [AIS](#ais)
-    - [Raymarine SeaTalk](#raymarine-seatalk1)
-- [Distribution](#distribution)
+    - [Raymarine SeaTalk<sup>1</sup>](#raymarine-seatalksup1sup)
+  - [Distribution](#distribution)
     - [Pre-built JARs](#pre-built-jars)
     - [Maven](#maven)
-- [Contributing](#contributing)
-- [References](#references)
+      - [Snapshots](#snapshots)
+  - [Contributing](#contributing)
+  - [References](#references)
+    - [Wikipedia](#wikipedia)
+    - [National Marine Electronics Association](#national-marine-electronics-association)
+    - [Navigation Center of U.S. Department of Homeland Security](#navigation-center-of-us-department-of-homeland-security)
+    - [Product Manuals and User Guides](#product-manuals-and-user-guides)
+    - [Miscellaneus](#miscellaneus)
+    - [No longer available](#no-longer-available)
 
 ## About
 
@@ -152,12 +160,15 @@ the library. See wiki for
 |MTW    |Water temperature in degrees Celcius
 |MWD    |Wind speed and direction.
 |MWV    |Wind speed and angle
+|OSD    |Own ship data
 |RMB    |Recommended minimum navigation information "type B"
 |RMC    |Recommended minimum navigation information "type C"
 |ROT    |Vessel's rate of turn
 |RPM    |Engine or shaft revolutions
 |RSA    |Rudder angle in degrees
+|RSD    |Radar system data
 |RTE    |GPS route data with list of waypoints
+|TLB    |Target label
 |TTM    |Tracked target message
 |TXT    |Text message
 |VBW    |Dual ground/water speed.

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,10 @@ Version 0.12.0-SNAPSHOT
 
   Contributions:
   - TTM parser by @NontasPantzopoulos
+  - TLB, OSD, and RSD sentences and parsers by @joshsweaney
+  - Changed some speed units (KMH, KNOT, MPH) to their base units
+    (KILOMETERS, NAUTICAL_MILES, STATUTE_MILES) so that more sentences
+    can use them @joshsweaney
 
 Version 0.11.0 (2019-07-06)
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ Version 0.12.0-SNAPSHOT
   - Changed some speed units (KMH, KNOT, MPH) to their base units
     (KILOMETERS, NAUTICAL_MILES, STATUTE_MILES) so that more sentences
     can use them @joshsweaney
+  - Added separate convenience methods for ship and cargo type strings @joshsweaney
 
 Version 0.11.0 (2019-07-06)
 

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@ along with Java Marine API. If not, see <http://www.gnu.org/licenses />.
                 <version>3.0.1</version>
                 <configuration>
                     <excludePackageNames>net.sf.marineapi.example</excludePackageNames>
+                    <source>1.8</source>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/net/sf/marineapi/ais/util/ShipType.java
+++ b/src/main/java/net/sf/marineapi/ais/util/ShipType.java
@@ -1,6 +1,6 @@
 /*
  * ShipType.java
- * Copyright (C) 2015 Lázár József
+ * Copyright (C) 2015-2020 Lázár József, Joshua Sweaney
  *
  * This file is part of Java Marine API.
  * <http://ktuukkan.github.io/marine-api/>
@@ -23,7 +23,7 @@ package net.sf.marineapi.ais.util;
 /**
  * Checks the ship type for validity.
  * 
- * @author Lázár József
+ * @author Lázár József, Joshua Sweaney
  */
 public class ShipType {
 
@@ -99,14 +99,81 @@ public class ShipType {
 			int d2 = type % 10;
 			if (0 <= d1 && d1 <= 9 && 0 <= d2 && d2 <= 9) {
 				switch(d1) {
-				case 0:
-					return FIRST_DIGIT[0] + " " + Integer.toString(type);
-				case 3:
-					return FIRST_DIGIT[3] + ", " + VESSEL[d2];
-				case 5: 
-					return SPECIAL[d2];
-				default:
-					return FIRST_DIGIT[d1] + ", " + SECOND_DIGIT[d2]; 
+					case 0:
+						return FIRST_DIGIT[0] + " " + Integer.toString(type);
+					case 3:
+						return FIRST_DIGIT[3] + ", " + VESSEL[d2];
+					case 5: 
+						return SPECIAL[d2];
+					default:
+						return FIRST_DIGIT[d1] + ", " + SECOND_DIGIT[d2]; 
+				}
+			}
+		}
+		return typeStr;
+	}
+
+	/**
+	 * Returns a string describing the first digit. Describes the type of vessel.
+	 * @param type Ship and cargo type indicator
+	 * @return String a text string describing the ship type digit
+	 */
+	static public String shipTypeToVesselString(int type) {
+		String typeStr ="N/A";
+		if (0 <= type && type <= 255) {
+			if (type >= 200)
+				return "Reserved for future use";
+			if (type >= 100)
+				return "Reserved for regional use";
+			if (type == 0)
+				return "Not available / no ship";
+
+			int d1 = type / 10;
+			int d2 = type % 10;
+			if (0 <= d1 && d1 <= 9 && 0 <= d2 && d2 <= 9) {
+				switch(d1) {
+					case 0:
+						return FIRST_DIGIT[0] + " " + Integer.toString(type); // Ship type not specified, so just print whole type number
+					case 3:
+						return FIRST_DIGIT[3]; // Vessel
+					case 5: 
+						return SPECIAL[d2]; // Describes special vessel types for vessels in U.S. waters
+					default:
+						return FIRST_DIGIT[d1]; // Ship type
+				}
+			}
+		}
+		return typeStr;		
+	}
+
+	/**
+	 * Returns a string describing the second digit. Usually describes the type
+	 * of cargo being carried, but may also describe the activity the vessel is engaged in.
+	 * @param type Ship and cargo type indicator
+	 * @return String a text string describing the cargo type digit
+	 */
+	static public String shipTypeToCargoString(int type) {
+		String typeStr ="N/A";
+		if (0 <= type && type <= 255) {
+			if (type >= 200)
+				return "Reserved for future use";
+			if (type >= 100)
+				return "Reserved for regional use";
+			if (type == 0)
+				return "Not available / no ship";
+
+			int d1 = type / 10;
+			int d2 = type % 10;
+			if (0 <= d1 && d1 <= 9 && 0 <= d2 && d2 <= 9) {
+				switch(d1) {
+					case 0:
+						return FIRST_DIGIT[0] + " " + Integer.toString(type); // Cargo not specified, so just print whole type number
+					case 3:
+						return VESSEL[d2]; // Describes an activity the vessel is engaged in
+					case 5: 
+						return SPECIAL[d2]; // Describes special vessel types for vessels in U.S. waters
+					default:
+						return SECOND_DIGIT[d2]; // Describes the cargo being carried
 				}
 			}
 		}

--- a/src/main/java/net/sf/marineapi/nmea/parser/MWVParser.java
+++ b/src/main/java/net/sf/marineapi/nmea/parser/MWVParser.java
@@ -125,7 +125,7 @@ class MWVParser extends SentenceParser implements MWVSentence {
 	 * .nmea.util.Units)
 	 */
 	public void setSpeedUnit(Units unit) {
-		if (unit == Units.METER || unit == Units.KMH || unit == Units.KNOT) {
+		if (unit == Units.METER || unit == Units.KILOMETERS || unit == Units.NAUTICAL_MILES) {
 			setCharValue(SPEED_UNITS, unit.toChar());
 			return;
 		}

--- a/src/main/java/net/sf/marineapi/nmea/parser/OSDParser.java
+++ b/src/main/java/net/sf/marineapi/nmea/parser/OSDParser.java
@@ -1,0 +1,207 @@
+/* 
+ * OSDParser.java
+ * Copyright (C) 2020 Joshua Sweaney
+ * 
+ * This file is part of Java Marine API.
+ * <http://ktuukkan.github.io/marine-api/>
+ * 
+ * Java Marine API is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * 
+ * Java Marine API is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java Marine API. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.sf.marineapi.nmea.parser;
+
+import java.util.Arrays;
+
+import net.sf.marineapi.nmea.sentence.OSDSentence;
+import net.sf.marineapi.nmea.sentence.SentenceId;
+import net.sf.marineapi.nmea.sentence.TalkerId;
+import net.sf.marineapi.nmea.util.DataStatus;
+import net.sf.marineapi.nmea.util.ReferenceSystem;
+import net.sf.marineapi.nmea.util.Units;
+
+/**
+ * OSD sentence parser
+ * 
+ * @author Joshua Sweaney
+ */
+public class OSDParser extends SentenceParser implements OSDSentence {
+
+    private static final int HEADING = 0;
+    private static final int HEADING_STATUS = 1;
+    private static final int COURSE = 2;
+    private static final int COURSE_REFERENCE = 3;
+    private static final int SPEED = 4;
+    private static final int SPEED_REFERENCE = 5;
+    private static final int VESSEL_SET = 6;
+    private static final int VESSEL_DRIFT = 7;
+    private static final int SPEED_UNITS = 8;
+
+    private static final Units[] VALID_SPEED_UNITS = {Units.KILOMETERS, Units.NAUTICAL_MILES, Units.STATUTE_MILES};
+
+    /**
+	 * Creates a new instance of OSD parser
+	 * 
+	 * @param nmea OSD sentence string.
+	 */
+	public OSDParser(String nmea) {
+        super(nmea, SentenceId.OSD);
+    }
+
+    /**
+	 * Creates OSD parser with empty sentence.
+	 * 
+	 * @param talker TalkerId to set
+	 */
+	public OSDParser(TalkerId talker) {
+		super(talker, SentenceId.OSD, 9);
+    }
+    
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#getHeading()
+     */
+    public double getHeading() {
+        return getDoubleValue(HEADING);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#getHeadingStatus()
+     */
+    public DataStatus getHeadingStatus() {
+        return DataStatus.valueOf(getCharValue(HEADING_STATUS));
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#getCourse()
+     */
+    public double getCourse() {
+        return getDoubleValue(COURSE);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#getCourseReference()
+     */
+    public ReferenceSystem getCourseReference() {
+        return ReferenceSystem.valueOf(getCharValue(COURSE_REFERENCE));
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#getSpeed()
+     */
+    public double getSpeed() {
+        return getDoubleValue(SPEED);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#getSpeedReference()
+     */
+    public ReferenceSystem getSpeedReference() {
+        return ReferenceSystem.valueOf(getCharValue(SPEED_REFERENCE));
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#getVesselSet()
+     */
+    public double getVesselSet() {
+        return getDoubleValue(VESSEL_SET);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#getVesselDrift()
+     */
+    public double getVesselDrift() {
+        return getDoubleValue(VESSEL_DRIFT);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#getSpeedUnits()
+     */
+    public Units getSpeedUnits() {
+        return Units.valueOf(getCharValue(SPEED_UNITS));
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#setHeading(double)
+     */
+    public void setHeading(double heading) {
+        setDoubleValue(HEADING, heading);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#setHeadingStatus(DataStatus)
+     */
+    public void setHeadingStatus(DataStatus status) {        
+        setCharValue(HEADING_STATUS, status.toChar());
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#setCourse(double)
+     */
+    public void setCourse(double course) {
+        setDoubleValue(COURSE, course);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#setCourseReference(ReferenceSystem)
+     */
+    public void setCourseReference(ReferenceSystem reference) {
+        setCharValue(COURSE_REFERENCE, reference.toChar());
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#setSpeed(double)
+     */
+    public void setSpeed(double speed) {
+        setDoubleValue(SPEED, speed);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#setSpeedReference(ReferenceSystem)
+     */
+    public void setSpeedReference(ReferenceSystem reference) {
+        setCharValue(SPEED_REFERENCE, reference.toChar());
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#setVesselSet(double)
+     */
+    public void setVesselSet(double set) {
+        setDoubleValue(VESSEL_SET, set);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#setVesselDrift(double)
+     */
+    public void setVesselDrift(double drift) {
+        setDoubleValue(VESSEL_DRIFT, drift);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.OSDSentence#setSpeedUnits(Units)
+     */
+    public void setSpeedUnits(Units units) {
+        if (Arrays.asList(VALID_SPEED_UNITS).contains(units)) {
+            setCharValue(SPEED_UNITS, units.toChar());
+        } else {
+            String err = "Speed units must be ";
+            for (int i = 0; i<VALID_SPEED_UNITS.length; i++) {
+                Units u = VALID_SPEED_UNITS[i];
+                err += u.name() + "(" + u.toChar() + ")";
+                if (i != VALID_SPEED_UNITS.length-1) {
+                    err += ", ";
+                }
+            }
+            throw new IllegalArgumentException(err);
+        }
+    }
+    
+}

--- a/src/main/java/net/sf/marineapi/nmea/parser/RSDParser.java
+++ b/src/main/java/net/sf/marineapi/nmea/parser/RSDParser.java
@@ -1,0 +1,266 @@
+/* 
+ * RSDParser.java
+ * Copyright (C) 2020 Joshua Sweaney
+ * 
+ * This file is part of Java Marine API.
+ * <http://ktuukkan.github.io/marine-api/>
+ * 
+ * Java Marine API is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * 
+ * Java Marine API is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java Marine API. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.sf.marineapi.nmea.parser;
+
+import java.util.Arrays;
+
+import net.sf.marineapi.nmea.sentence.RSDSentence;
+import net.sf.marineapi.nmea.sentence.SentenceId;
+import net.sf.marineapi.nmea.sentence.TalkerId;
+import net.sf.marineapi.nmea.util.DisplayRotation;
+import net.sf.marineapi.nmea.util.Units;
+
+/**
+ * RSD sentence parser
+ * 
+ * @author Joshua Sweaney
+ */
+public class RSDParser extends SentenceParser implements RSDSentence {
+
+    private static final int ORIGIN_ONE_RANGE = 0;
+    private static final int ORIGIN_ONE_BEARING = 1;
+    private static final int VRM_ONE_RANGE = 2;
+    private static final int EBL_ONE_BEARING = 3;
+    private static final int ORIGIN_TWO_RANGE = 4;
+    private static final int ORIGIN_TWO_BEARING = 5;
+    private static final int VRM_TWO_RANGE = 6;
+    private static final int EBL_TWO_BEARING = 7;
+    private static final int CURSOR_RANGE = 8;
+    private static final int CURSOR_BEARING = 9;
+    private static final int RANGE_SCALE = 10;
+    private static final int RANGE_UNITS = 11;
+    private static final int DISPLAY_ROTATION = 12;
+
+    private static final Units[] VALID_RANGE_UNITS = {Units.KILOMETERS, Units.NAUTICAL_MILES, Units.STATUTE_MILES};
+
+    /**
+	 * Creates a new instance of RSD parser
+	 * 
+	 * @param nmea RSD sentence string.
+	 */
+	public RSDParser(String nmea) {
+        super(nmea, SentenceId.RSD);
+    }
+
+    /**
+	 * Creates RSD parser with empty sentence.
+	 * 
+	 * @param talker TalkerId to set
+	 */
+	public RSDParser(TalkerId talker) {
+		super(talker, SentenceId.RSD, 13);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#getOriginOneRange()
+     */
+    public double getOriginOneRange() {
+        return getDoubleValue(ORIGIN_ONE_RANGE);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#getOriginOneBearing()
+     */
+    public double getOriginOneBearing() {
+        return getDoubleValue(ORIGIN_ONE_BEARING);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#getVRMOneRange()
+     */
+    public double getVRMOneRange() {
+        return getDoubleValue(VRM_ONE_RANGE);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#getEBLOneBearing()
+     */
+    public double getEBLOneBearing() {
+        return getDoubleValue(EBL_ONE_BEARING);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#getOriginTwoRange()
+     */
+    public double getOriginTwoRange() {
+        return getDoubleValue(ORIGIN_TWO_RANGE);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#getOriginTwoBearing()
+     */
+    public double getOriginTwoBearing() {
+        return getDoubleValue(ORIGIN_TWO_BEARING);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#getVRMTwoRange()
+     */
+    public double getVRMTwoRange() {
+        return getDoubleValue(VRM_TWO_RANGE);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#getEBLTwoBearing()
+     */
+    public double getEBLTwoBearing() {
+        return getDoubleValue(EBL_TWO_BEARING);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#getCursorRange()
+     */
+    public double getCursorRange() {
+        return getDoubleValue(CURSOR_RANGE);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#getCursorBearing()
+     */
+    public double getCursorBearing() {
+        return getDoubleValue(CURSOR_BEARING);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#getRangeScale()
+     */
+    public double getRangeScale() {
+        return getDoubleValue(RANGE_SCALE);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#getRangeUnits()
+     */
+    public Units getRangeUnits() {
+        return Units.valueOf(getCharValue(RANGE_UNITS));
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#getDisplayRotation()
+     */
+    public DisplayRotation getDisplayRotation() {
+        return DisplayRotation.valueOf(getCharValue(DISPLAY_ROTATION));
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#setOriginOneRange(double)
+     */
+    public void setOriginOneRange(double range) {
+        setDoubleValue(ORIGIN_ONE_RANGE, range);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#setOriginOneBearing(double)
+     */
+    public void setOriginOneBearing(double bearing) {
+        setDoubleValue(ORIGIN_ONE_BEARING, bearing);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#setVRMOneRange(double)
+     */
+    public void setVRMOneRange(double range) {
+        setDoubleValue(VRM_ONE_RANGE, range);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#setEBLOneBearing(double)
+     */
+    public void setEBLOneBearing(double bearing) {
+        setDoubleValue(EBL_ONE_BEARING, bearing);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#setOriginTwoRange(double)
+     */
+    public void setOriginTwoRange(double range) {
+        setDoubleValue(ORIGIN_TWO_RANGE, range);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#setOriginTwoBearing(double)
+     */
+    public void setOriginTwoBearing(double bearing) {
+        setDoubleValue(ORIGIN_TWO_BEARING, bearing);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#setVRMTwoRange(double)
+     */
+    public void setVRMTwoRange(double range) {
+        setDoubleValue(VRM_TWO_RANGE, range);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#setEBLTwoBearing(double)
+     */
+    public void setEBLTwoBearing(double bearing) {
+        setDoubleValue(EBL_TWO_BEARING, bearing);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#setCursorRange(double)
+     */
+    public void setCursorRange(double range) {
+        setDoubleValue(CURSOR_RANGE, range);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#setCursorBearing(double)
+     */
+    public void setCursorBearing(double bearing) {
+        setDoubleValue(CURSOR_BEARING, bearing);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#setRangeScale(double)
+     */
+    public void setRangeScale(double scale) {
+        setDoubleValue(RANGE_SCALE, scale);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#setRangeUnits(Units)
+     */
+    public void setRangeUnits(Units units) {
+        if (Arrays.asList(VALID_RANGE_UNITS).contains(units)) {
+            setCharValue(RANGE_UNITS, units.toChar());
+        } else {
+            String err = "Range units must be ";
+            for (int i = 0; i<VALID_RANGE_UNITS.length; i++) {
+                Units u = VALID_RANGE_UNITS[i];
+                err += u.name() + "(" + u.toChar() + ")";
+                if (i != VALID_RANGE_UNITS.length-1) {
+                    err += ", ";
+                }
+            }
+            throw new IllegalArgumentException(err);
+        }
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.RSDSentence#setDisplayRotation(DisplayRotation)
+     */
+    public void setDisplayRotation(DisplayRotation rotation) {
+        setCharValue(DISPLAY_ROTATION, rotation.toChar());
+    }
+    
+}

--- a/src/main/java/net/sf/marineapi/nmea/parser/SentenceFactory.java
+++ b/src/main/java/net/sf/marineapi/nmea/parser/SentenceFactory.java
@@ -306,12 +306,15 @@ public final class SentenceFactory {
 		registerParser(tempParsers, "MTA", MTAParser.class);
 		registerParser(tempParsers, "MTW", MTWParser.class);
 		registerParser(tempParsers, "MWV", MWVParser.class);
+		registerParser(tempParsers, "OSD", OSDParser.class);
 		registerParser(tempParsers, "RMB", RMBParser.class);
 		registerParser(tempParsers, "RMC", RMCParser.class);
 		registerParser(tempParsers, "RPM", RPMParser.class);
 		registerParser(tempParsers, "ROT", ROTParser.class);
 		registerParser(tempParsers, "RTE", RTEParser.class);
 		registerParser(tempParsers, "RSA", RSAParser.class);
+		registerParser(tempParsers, "RSD", RSDParser.class);
+		registerParser(tempParsers, "TLB", TLBParser.class);
 		registerParser(tempParsers, "TLL", TLLParser.class);
 		registerParser(tempParsers, "TTM", TTMParser.class);
 		registerParser(tempParsers, "TXT", TXTParser.class);

--- a/src/main/java/net/sf/marineapi/nmea/parser/SentenceParser.java
+++ b/src/main/java/net/sf/marineapi/nmea/parser/SentenceParser.java
@@ -123,8 +123,8 @@ public class SentenceParser implements Sentence {
 	 * @param size Number of sentence data fields
 	 */
 	protected SentenceParser(char begin, TalkerId talker, String type, int size) {
-		if (size < 1) {
-			throw new IllegalArgumentException("Minimum number of fields is 1");
+		if (size < 0) {
+			throw new IllegalArgumentException("Size cannot be negative.");
 		}
 		if (talker == null) {
 			throw new IllegalArgumentException("Talker ID must be specified");

--- a/src/main/java/net/sf/marineapi/nmea/parser/TLBParser.java
+++ b/src/main/java/net/sf/marineapi/nmea/parser/TLBParser.java
@@ -1,0 +1,135 @@
+/* 
+ * TLBParser.java
+ * Copyright (C) 2020 Joshua Sweaney
+ * 
+ * This file is part of Java Marine API.
+ * <http://ktuukkan.github.io/marine-api/>
+ * 
+ * Java Marine API is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * 
+ * Java Marine API is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java Marine API. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.sf.marineapi.nmea.parser;
+
+import net.sf.marineapi.nmea.sentence.SentenceId;
+import net.sf.marineapi.nmea.sentence.TLBSentence;
+import net.sf.marineapi.nmea.sentence.TalkerId;
+
+/**
+ * TLB sentence parser
+ * 
+ * @author Joshua Sweaney
+ */
+class TLBParser extends SentenceParser implements TLBSentence {
+
+    // field indices
+    private static final int FIRST_PAIR = 0;
+
+    /**
+	 * Creates a new instance of TLB parser
+	 * 
+	 * @param nmea TLB sentence string.
+	 */
+	public TLBParser(String nmea) {
+        super(nmea, SentenceId.TLB);
+        
+        if ((getFieldCount() % 2) != 0) {
+            throw new IllegalArgumentException("Invalid TLB sentence. Must contain pairs of target numbers and labels.");
+        }
+    }
+    
+    /**
+	 * Creates TLB parser with empty sentence. The created TLB sentence contains
+	 * no target id,label pairs.
+	 * 
+	 * @param talker TalkerId to set
+	 */
+	public TLBParser(TalkerId talker) {
+		super(talker, SentenceId.TLB, 0);
+	}
+    
+    /**
+     * @see net.sf.marineapi.nmea.sentence.TLBSentence#getTargetIds()
+     */
+    public int[] getTargetIds() {
+        int[] ids = new int[(int) (getFieldCount() / 2)];
+
+        for (int i = 0, j = 0; j<ids.length; i+=2, j++) {
+            ids[j] = getIntValue(i);
+        }
+
+        return ids;
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.TLBSentence#getTargetLabels()
+     */
+    public String[] getTargetLabels() {
+        String[] labels = new String[(int) (getFieldCount() / 2)];
+
+        for (int i = 1, j = 0; j<labels.length; i+=2, j++) {
+            try {
+                labels[j] = getStringValue(i);
+            } catch (DataNotAvailableException ex) {
+                labels[j] = "";
+            }            
+        }
+
+        return labels;
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.TLBSentence#addTargetLabel(int, java.lang.String)
+     */
+    public void addTargetLabel(int targetId, String targetLabel) {
+        int[] ids = getTargetIds();
+        String[] labels = getTargetLabels();
+
+        String[] newFields = new String[(ids.length+1)*2];
+
+        // Since the ID part of each (ID,label) pair comes first, we will consider that
+        // to be authoratative about the number of pairs that should exist.
+        // If the labels array is shorter, empty strings are used. If longer, only
+        // pairs up to ids.length are added.
+        for (int i = 0, j = 0; i<ids.length; i++, j+=2) {
+            newFields[j] = String.valueOf(ids[i]);
+            if (i < labels.length) {
+                newFields[j+1] = labels[i];
+            } else {
+                newFields[j+1] = "";
+            }
+        }
+
+        // Finally, add the new id,label pair
+        newFields[newFields.length-2] = String.valueOf(targetId);
+        newFields[newFields.length-1] = targetLabel;
+
+        setStringValues(FIRST_PAIR, newFields);
+    }
+
+    /**
+     * @see net.sf.marineapi.nmea.sentence.TLBSentence#setTargetPairs(int, java.lang.String)
+     */
+    public void setTargetPairs(int[] ids, String[] labels) {
+        if (ids.length != labels.length) {
+            throw new IllegalArgumentException("The ID and Label arrays must be the same length.");
+        }
+
+        String[] newFields = new String[ids.length*2];
+        for (int i = 0, j = 0; i<ids.length; i++, j+=2) {
+            newFields[j] = String.valueOf(ids[i]);
+            newFields[j+1] = labels[i];
+        }
+        
+        setStringValues(FIRST_PAIR, newFields);
+    }
+}

--- a/src/main/java/net/sf/marineapi/nmea/parser/VDRParser.java
+++ b/src/main/java/net/sf/marineapi/nmea/parser/VDRParser.java
@@ -57,7 +57,7 @@ class VDRParser extends SentenceParser implements VDRSentence {
 		super(tid, SentenceId.VDR, 6);
 		setCharValue(TRUE_INDICATOR, 'T');
 		setCharValue(MAGN_INDICATOR, 'M');
-		setCharValue(SPEED_UNITS, Units.KNOT.toChar());
+		setCharValue(SPEED_UNITS, Units.NAUTICAL_MILES.toChar());
 	}
 
 	/*

--- a/src/main/java/net/sf/marineapi/nmea/sentence/MWVSentence.java
+++ b/src/main/java/net/sf/marineapi/nmea/sentence/MWVSentence.java
@@ -50,8 +50,8 @@ public interface MWVSentence extends Sentence {
 	/**
 	 * Returns the wind speed unit.
 	 * 
-	 * @return {@link Units#METER} for meters per second, {@link Units#KMH} for
-	 *         kilometers per hour and {@link Units#KNOT} for knots.
+	 * @return {@link Units#METER} for meters per second, {@link Units#KILOMETERS} for
+	 *         kilometers per hour and {@link Units#NAUTICAL_MILES} for knots.
 	 */
 	Units getSpeedUnit();
 
@@ -87,8 +87,8 @@ public interface MWVSentence extends Sentence {
 	/**
 	 * Set wind speed unit.
 	 * 
-	 * @param unit {@link Units#METER} for meters per second, {@link Units#KMH}
-	 *            for kilometers per hour and {@link Units#KNOT} for knots.
+	 * @param unit {@link Units#METER} for meters per second, {@link Units#KILOMETERS}
+	 *            for kilometers per hour and {@link Units#NAUTICAL_MILES} for knots.
 	 * @throws IllegalArgumentException If trying to set invalid unit
 	 */
 	void setSpeedUnit(Units unit);

--- a/src/main/java/net/sf/marineapi/nmea/sentence/OSDSentence.java
+++ b/src/main/java/net/sf/marineapi/nmea/sentence/OSDSentence.java
@@ -133,43 +133,43 @@ public interface OSDSentence {
 
     /**
      * Set ownship heading
-     * @param double the heading
+     * @param heading the heading
      */
     void setHeading(double heading);
 
     /**
      * Set the heading data status
-     * @param DataStatus the status
+     * @param status the status
      */
     void setHeadingStatus(DataStatus status);
 
     /**
      * Set ownship course
-     * @param double the course
+     * @param course the course
      */
     void setCourse(double course);
 
     /**
      * Set the reference system for the course
-     * @param ReferenceSystem the reference
+     * @param reference the reference
      */
     void setCourseReference(ReferenceSystem reference);
 
     /**
      * Set ownship speed
-     * @param double the speed
+     * @param speed the speed
      */
     void setSpeed(double speed);
 
     /**
      * Set the reference system for the speed
-     * @param ReferenceSystem the reference
+     * @param reference the reference
      */
     void setSpeedReference(ReferenceSystem reference);
 
     /**
      * Set the vessel set
-     * @param double the vessel set
+     * @param set the vessel set
      */
     void setVesselSet(double set);
 
@@ -181,7 +181,7 @@ public interface OSDSentence {
 
     /**
      * Set the speed units
-     * @param Units the units
+     * @param units the units
      */
     void setSpeedUnits(Units units);
     

--- a/src/main/java/net/sf/marineapi/nmea/sentence/OSDSentence.java
+++ b/src/main/java/net/sf/marineapi/nmea/sentence/OSDSentence.java
@@ -1,0 +1,188 @@
+/* 
+ * OSDSentence.java
+ * Copyright (C) 2020 Joshua Sweaney
+ * 
+ * This file is part of Java Marine API.
+ * <http://ktuukkan.github.io/marine-api/>
+ * 
+ * Java Marine API is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * 
+ * Java Marine API is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java Marine API. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.sf.marineapi.nmea.sentence;
+
+import net.sf.marineapi.nmea.util.DataStatus;
+import net.sf.marineapi.nmea.util.ReferenceSystem;
+import net.sf.marineapi.nmea.util.Units;
+
+/**
+ * Own ship data.<br>
+ * Gives the movement vector of the ship.<br>
+ * 
+ * Includes (in this order): Heading (degrees true), Heading status {@link net.sf.marineapi.nmea.util.DataStatus} <br>
+ * Vessel course (degrees true), Course reference {@link net.sf.marineapi.nmea.util.ReferenceSystem},<br>
+ * Vessel speed, Speed reference (ReferenceSystem), Vessel set (degrees true), vessel drift,<br>
+ * Speed units {@link net.sf.marineapi.nmea.util.Units}<br>
+ * 
+ * Example:<br>
+ * {@code $RAOSD,35.1,A,36.0,P,10.2,P,15.3,0.1,N*41<CR><LF> }
+ * 
+ * @author Joshua Sweaney
+ */
+public interface OSDSentence {
+
+    /**
+     * Get ownship heading
+     * 
+     * @return Double ownship heading
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getHeading();
+
+    /**
+     * Get the status of heading data
+     * @return DataStatus the status
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    DataStatus getHeadingStatus();
+
+    /**
+     * Get the course of ownship
+     * @return Double the course
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getCourse();
+
+    /**
+     * Get the reference system used to calculate course
+     * @return ReferenceSystem the reference
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    ReferenceSystem getCourseReference();
+
+    /**
+     * Get ownship speed
+     * @return Double the speed
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getSpeed();
+
+    /**
+     * Get the reference system used to calculate speed
+     * @return ReferenceSystem the reference
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    ReferenceSystem getSpeedReference();
+
+    /**
+     * Get the vessel set (water current direction)
+     * @return Double the set
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getVesselSet();
+
+    /**
+     * Get the vessel drift
+     * @return double the drift
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getVesselDrift();
+
+    /**
+     * Get the units of speed measurements
+     * @return Units the speed units (K, N, S)
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    Units getSpeedUnits();
+
+    /**
+     * Set ownship heading
+     * @param double the heading
+     */
+    void setHeading(double heading);
+
+    /**
+     * Set the heading data status
+     * @param DataStatus the status
+     */
+    void setHeadingStatus(DataStatus status);
+
+    /**
+     * Set ownship course
+     * @param double the course
+     */
+    void setCourse(double course);
+
+    /**
+     * Set the reference system for the course
+     * @param ReferenceSystem the reference
+     */
+    void setCourseReference(ReferenceSystem reference);
+
+    /**
+     * Set ownship speed
+     * @param double the speed
+     */
+    void setSpeed(double speed);
+
+    /**
+     * Set the reference system for the speed
+     * @param ReferenceSystem the reference
+     */
+    void setSpeedReference(ReferenceSystem reference);
+
+    /**
+     * Set the vessel set
+     * @param double the vessel set
+     */
+    void setVesselSet(double set);
+
+    /**
+     * Set the vessel drift
+     * @param drift the vessel drift
+     */
+    void setVesselDrift(double drift);
+
+    /**
+     * Set the speed units
+     * @param Units the units
+     */
+    void setSpeedUnits(Units units);
+    
+}

--- a/src/main/java/net/sf/marineapi/nmea/sentence/RSDSentence.java
+++ b/src/main/java/net/sf/marineapi/nmea/sentence/RSDSentence.java
@@ -1,0 +1,244 @@
+/* 
+ * RSDSentence.java
+ * Copyright (C) 2020 Joshua Sweaney
+ * 
+ * This file is part of Java Marine API.
+ * <http://ktuukkan.github.io/marine-api/>
+ * 
+ * Java Marine API is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * 
+ * Java Marine API is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java Marine API. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.sf.marineapi.nmea.sentence;
+
+import net.sf.marineapi.nmea.util.DisplayRotation;
+import net.sf.marineapi.nmea.util.Units;
+
+/**
+ * Radar system data<br>
+ * Contains information about variable range markers (VRM), electronic bearing lines (EBL),
+ * the range scale in use, the display rotation, and the current cursor position.
+ * Example:<br>
+ * {@code $RARSD,12,90,24,45,6,270,12,315,6.5,118,96,N,N*5A<CR><LF> }
+ * 
+ * @author Joshua Sweaney
+ */
+public interface RSDSentence {
+
+    /**
+     * Get the range of the origin for VRM1 and EBL1.
+     * @return double the range of Origin 1
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getOriginOneRange();
+
+    /**
+     * Get the bearing of the origin for VRM1 and EBL1 (in degrees), from 0 degrees.
+     * @return double the bearing of Origin 1
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getOriginOneBearing();
+
+    /**
+     * Get the range of variable range marker 1
+     * @return double VRM 1 range
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getVRMOneRange();
+
+    /**
+     * Get the bearing of electronic bearing line 1, from 0 degrees
+     * @return double EBL 1 bearing
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getEBLOneBearing();
+
+    /**
+     * Get the range of the origin for VRM2 and EBL2.
+     * @return double the range of Origin 2
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getOriginTwoRange();
+
+    /**
+     * Get the bearing of the origin for VRM2 and EBL2 (in degrees), from 0 degrees.
+     * @return double the bearing of Origin 2
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getOriginTwoBearing();
+
+    /**
+     * Get the range of variable range marker 2
+     * @return double VRM 2 range
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getVRMTwoRange();
+
+    /**
+     * Get the bearing of electronic bearing line 2, from 0 degrees
+     * @return double EBL 2 bearing
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getEBLTwoBearing();
+
+    /**
+     * Get current cursor position range
+     * @return double current cursor range
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getCursorRange();
+
+    /**
+     * Get current cursor position bearing
+     * @return double current cursor bearing
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getCursorBearing();
+
+    /**
+     * Get the current selected range scale
+     * @return double current range scale
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    double getRangeScale();
+
+    /**
+     * Get the units used for range measurements in this sentence
+     * @return Units the units used for the ranges (either kilometres, nautical miles, or statute miles)
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    Units getRangeUnits();
+
+    /**
+     * Get the selected display rotation of the radar system
+     * @return DisplayRotation the display rotation
+     * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+     */
+    DisplayRotation getDisplayRotation();
+
+    /**
+     * Set the range for origin one
+     * @param bearing double the range
+     */
+    void setOriginOneRange(double range);
+
+    /**
+     * Set the bearing for origin one
+     * @param bearing double the bearing
+     */
+    void setOriginOneBearing(double bearing);
+    
+    /**
+     * Set the range of VRM one
+     * @param range double the range
+     */
+    void setVRMOneRange(double range);
+
+    /**
+     * Set the bearing of EBL one
+     * @param bearing double the bearing
+     */
+    void setEBLOneBearing(double bearing);
+
+    /**
+     * Set the range for origin two
+     * @param bearing double the range
+     */
+    void setOriginTwoRange(double range);
+
+    /**
+     * Set the bearing for origin two
+     * @param bearing double the bearing
+     */
+    void setOriginTwoBearing(double bearing);
+    
+    /**
+     * Set the range of VRM two
+     * @param range double the range
+     */
+    void setVRMTwoRange(double range);
+
+    /**
+     * Set the bearing of EBL two
+     * @param bearing double the bearing
+     */
+    void setEBLTwoBearing(double bearing);
+
+    /**
+     * Set the cursor range
+     * @param range double the range
+     */
+    void setCursorRange(double range);
+
+    /**
+     * Set the cursor bearing
+     * @param bearing double the bearing
+     */
+    void setCursorBearing(double bearing);
+
+    /**
+     * Set the range scale
+     * @param rangeScale double the range scale
+     */
+    void setRangeScale(double rangeScale);
+
+    /**
+     * Set the range units
+     * @param Units the units used for the ranges (either kilometres, nautical miles, or statute miles)
+     */
+    void setRangeUnits(Units units);
+
+    /**
+     * Set the display rotation
+     * @param rotation the display rotation
+     */
+    void setDisplayRotation(DisplayRotation rotation);
+}

--- a/src/main/java/net/sf/marineapi/nmea/sentence/RSDSentence.java
+++ b/src/main/java/net/sf/marineapi/nmea/sentence/RSDSentence.java
@@ -166,31 +166,31 @@ public interface RSDSentence {
 
     /**
      * Set the range for origin one
-     * @param bearing double the range
+     * @param range the range
      */
     void setOriginOneRange(double range);
 
     /**
      * Set the bearing for origin one
-     * @param bearing double the bearing
+     * @param bearing the bearing
      */
     void setOriginOneBearing(double bearing);
     
     /**
      * Set the range of VRM one
-     * @param range double the range
+     * @param range the range
      */
     void setVRMOneRange(double range);
 
     /**
      * Set the bearing of EBL one
-     * @param bearing double the bearing
+     * @param bearing the bearing
      */
     void setEBLOneBearing(double bearing);
 
     /**
      * Set the range for origin two
-     * @param bearing double the range
+     * @param range the range
      */
     void setOriginTwoRange(double range);
 
@@ -202,37 +202,37 @@ public interface RSDSentence {
     
     /**
      * Set the range of VRM two
-     * @param range double the range
+     * @param range the range
      */
     void setVRMTwoRange(double range);
 
     /**
      * Set the bearing of EBL two
-     * @param bearing double the bearing
+     * @param bearing the bearing
      */
     void setEBLTwoBearing(double bearing);
 
     /**
      * Set the cursor range
-     * @param range double the range
+     * @param range the range
      */
     void setCursorRange(double range);
 
     /**
      * Set the cursor bearing
-     * @param bearing double the bearing
+     * @param bearing the bearing
      */
     void setCursorBearing(double bearing);
 
     /**
      * Set the range scale
-     * @param rangeScale double the range scale
+     * @param rangeScale the range scale
      */
     void setRangeScale(double rangeScale);
 
     /**
      * Set the range units
-     * @param Units the units used for the ranges (either kilometres, nautical miles, or statute miles)
+     * @param units the units used for the ranges (either kilometres, nautical miles, or statute miles)
      */
     void setRangeUnits(Units units);
 

--- a/src/main/java/net/sf/marineapi/nmea/sentence/SentenceId.java
+++ b/src/main/java/net/sf/marineapi/nmea/sentence/SentenceId.java
@@ -81,6 +81,8 @@ public enum SentenceId {
     MTW,
     /** Wind speed and angle */
     MWV,
+    /** Own ship data */
+    OSD,
     /** Recommended minimum navigation information */
     RMB,
     /** Recommended minimum specific GPS/TRANSIT data */
@@ -91,8 +93,12 @@ public enum SentenceId {
     RPM,
     /** Rudder angle, measured in degrees */
     RSA,
+    /** Radar system data */
+    RSD,
     /** Route data and waypoint list */
     RTE,
+    /** Target Label */
+    TLB,
     /** Tracked target Longitude Latitude*/
     TLL,
     /** Tracked target */

--- a/src/main/java/net/sf/marineapi/nmea/sentence/TLBSentence.java
+++ b/src/main/java/net/sf/marineapi/nmea/sentence/TLBSentence.java
@@ -68,7 +68,8 @@ public interface TLBSentence extends Sentence {
      * Sets the target (id,label) pairs in this sentence. The size of each
      * array must be identical. The nth position in each array corresponds
      * to the nth position in the other array.
-     * @param targetIds int array of target IDs
+     * @param targetIds array of target IDs
+     * @param targetLabels array of target labels
      * @throws java.lang.IllegalArgumentException If array sizes are not the same
      */
     void setTargetPairs(int[] targetIds, String[] targetLabels);

--- a/src/main/java/net/sf/marineapi/nmea/sentence/TLBSentence.java
+++ b/src/main/java/net/sf/marineapi/nmea/sentence/TLBSentence.java
@@ -1,0 +1,76 @@
+/* 
+ * TLBSentence.java
+ * Copyright (C) 2020 Joshua Sweaney
+ * 
+ * This file is part of Java Marine API.
+ * <http://ktuukkan.github.io/marine-api/>
+ * 
+ * Java Marine API is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * 
+ * Java Marine API is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java Marine API. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.sf.marineapi.nmea.sentence;
+
+/**
+ * Target label data in pairs of target IDs and target labels.
+ * Example:<br>
+ * {@code $RATLB,3,SHIPTHREE,5,SHIPFIVE,99,SHIP99*1F}
+ * 
+ * @author Joshua Sweaney
+ */
+public interface TLBSentence extends Sentence {
+
+    /**
+	 * Get the list of target IDs listed in this sentence.
+     * 
+     * The nth array element returned by this method, corresponds
+     * to the nth array element returned by {@link TLBSentence#getTargetLabels()}.
+	 * 
+	 * @return targets IDs as int array
+	 * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+	 */
+    int[] getTargetIds();
+
+    /**
+	 * Get the list of target labels listed in this sentence.
+     * 
+     * The nth array element returned by this method, corresponds
+     * to the nth array element returned by {@link TLBSentence#getTargetIds()}.
+	 * 
+	 * @return target labels as String array
+	 * @throws net.sf.marineapi.nmea.parser.DataNotAvailableException If the data is
+	 *             not available.
+	 * @throws net.sf.marineapi.nmea.parser.ParseException If the field contains
+	 *             unexpected or illegal value.
+	 */
+    String[] getTargetLabels();
+
+    /**
+     * Adds a target (id,label) pair to this sentence.
+     * @param targetId int The target ID of the pair
+     * @param targetLabel String The label of the pair
+     */
+    void addTargetLabel(int targetId, String targetLabel);
+
+    /**
+     * Sets the target (id,label) pairs in this sentence. The size of each
+     * array must be identical. The nth position in each array corresponds
+     * to the nth position in the other array.
+     * @param targetIds int array of target IDs
+     * @throws java.lang.IllegalArgumentException If array sizes are not the same
+     */
+    void setTargetPairs(int[] targetIds, String[] targetLabels);
+    
+}

--- a/src/main/java/net/sf/marineapi/nmea/util/DisplayRotation.java
+++ b/src/main/java/net/sf/marineapi/nmea/util/DisplayRotation.java
@@ -1,6 +1,6 @@
 /* 
- * Units.java
- * Copyright (C) 2010 Kimmo Tuukkanen
+ * DisplayRotation.java
+ * Copyright (C) 2020 Joshua Sweaney
  * 
  * This file is part of Java Marine API.
  * <http://ktuukkan.github.io/marine-api/>
@@ -21,43 +21,27 @@
 package net.sf.marineapi.nmea.util;
 
 /**
- * Defines the supported units of measure.
- *  
- * @author Kimmo Tuukkanen
- *
+ * Defines the various display rotations a navigational display
+ * (such as an ARPA) can select.
+ * 
+ * @see net.sf.marineapi.nmea.sentence.RSDSentence
+ * 
+ * @author Joshua Sweaney
  */
-public enum Units {
+public enum DisplayRotation {
 
-	/** Pressure in bars */
-	BARS('B'),
-	
-	/** Temperature in degrees Celsius (centigrade) */
-	CELSIUS('C'),
+    /** Course up, course-over-ground up, degrees true */
+    COURSE_UP('C'),
 
-	/** Depth in fathoms */
-	FATHOMS('F'),
+    /** Head up, ship's heading (centre line) pointing up */
+    HEAD_UP('H'),
 
-	/** Length in feet */
-	FEET('f'),
+    /** North up, true north 0 degrees is up */
+    NORTH_UP('N');
 
-	/** Distance/pressure in inches  */
-	INCHES('I'),
-	
-	/** Kilometers - used for distance, and speed (as kilometers per hour) */
-	KILOMETERS('K'),
+    private char ch;
 
-	/** Length in meter */
-	METER('M'),
-	
-	/** Nautical miles - used for distance, and for speed (nautical miles per hour, which are knots) */
-	NAUTICAL_MILES('N'),
-
-	/** Statute miles - used for distance, and for speed (as miles per hour/mph) */
-	STATUTE_MILES('S');
-
-	private char ch;
-
-	private Units(char c) {
+	private DisplayRotation(char c) {
 		ch = c;
 	}
 
@@ -73,15 +57,16 @@ public enum Units {
 	/**
 	 * Get the enum corresponding to specified char.
 	 * 
-	 * @param ch Char indicator for unit
-	 * @return Units enum
+	 * @param ch Char indicator for display rotation
+	 * @return DisplayRotation enum
 	 */
-	public static Units valueOf(char ch) {
-		for (Units u : values()) {
-			if (u.toChar() == ch) {
-				return u;
+	public static DisplayRotation valueOf(char ch) {
+		for (DisplayRotation r : values()) {
+			if (r.toChar() == ch) {
+				return r;
 			}
 		}
 		return valueOf(String.valueOf(ch));
 	}
+    
 }

--- a/src/main/java/net/sf/marineapi/nmea/util/ReferenceSystem.java
+++ b/src/main/java/net/sf/marineapi/nmea/util/ReferenceSystem.java
@@ -1,6 +1,6 @@
 /* 
- * Units.java
- * Copyright (C) 2010 Kimmo Tuukkanen
+ * ReferenceSystem.java
+ * Copyright (C) 2020 Joshua Sweaney
  * 
  * This file is part of Java Marine API.
  * <http://ktuukkan.github.io/marine-api/>
@@ -21,43 +21,28 @@
 package net.sf.marineapi.nmea.util;
 
 /**
- * Defines the supported units of measure.
- *  
- * @author Kimmo Tuukkanen
- *
+ * Defines the various reference systems that can be used to calculate
+ * a vessel's kinematics such as speed and course.
+ * 
+ * @see net.sf.marineapi.nmea.sentence.OSDSentence
+ * 
+ * @author Joshua Sweaney
  */
-public enum Units {
+public enum ReferenceSystem {
 
-	/** Pressure in bars */
-	BARS('B'),
-	
-	/** Temperature in degrees Celsius (centigrade) */
-	CELSIUS('C'),
+    BOTTOM_TRACKING_LOG('B'),
 
-	/** Depth in fathoms */
-	FATHOMS('F'),
+    MANUALLY_ENTERED('M'),
 
-	/** Length in feet */
-	FEET('f'),
+    WATER_REFERENCED('W'),
 
-	/** Distance/pressure in inches  */
-	INCHES('I'),
-	
-	/** Kilometers - used for distance, and speed (as kilometers per hour) */
-	KILOMETERS('K'),
+    RADAR_TRACKING('R'),
 
-	/** Length in meter */
-	METER('M'),
-	
-	/** Nautical miles - used for distance, and for speed (nautical miles per hour, which are knots) */
-	NAUTICAL_MILES('N'),
+    POSITIONING_SYSTEM_GROUND_REFERENCE('P');
 
-	/** Statute miles - used for distance, and for speed (as miles per hour/mph) */
-	STATUTE_MILES('S');
+    private char ch;
 
-	private char ch;
-
-	private Units(char c) {
+	private ReferenceSystem(char c) {
 		ch = c;
 	}
 
@@ -73,15 +58,16 @@ public enum Units {
 	/**
 	 * Get the enum corresponding to specified char.
 	 * 
-	 * @param ch Char indicator for unit
-	 * @return Units enum
+	 * @param ch Char indicator for reference
+	 * @return ReferenceSystem enum
 	 */
-	public static Units valueOf(char ch) {
-		for (Units u : values()) {
-			if (u.toChar() == ch) {
-				return u;
+	public static ReferenceSystem valueOf(char ch) {
+		for (ReferenceSystem r : values()) {
+			if (r.toChar() == ch) {
+				return r;
 			}
 		}
 		return valueOf(String.valueOf(ch));
 	}
+    
 }

--- a/src/test/java/net/sf/marineapi/nmea/io/SentenceReaderTest.java
+++ b/src/test/java/net/sf/marineapi/nmea/io/SentenceReaderTest.java
@@ -136,7 +136,7 @@ public class SentenceReaderTest {
 		});
 
 		reader.start();
-		Thread.sleep(100);
+		Thread.sleep(1000);
 
 		assertFalse(received.isEmpty());
 		assertEquals(server.TXT, received.get(0).toString());

--- a/src/test/java/net/sf/marineapi/nmea/parser/MWVTest.java
+++ b/src/test/java/net/sf/marineapi/nmea/parser/MWVTest.java
@@ -187,8 +187,8 @@ public class MWVTest {
 	 */
 	@Test
 	public void testSetSpeedUnit() {
-		mwv.setSpeedUnit(Units.KMH);
-		assertEquals(Units.KMH, mwv.getSpeedUnit());
+		mwv.setSpeedUnit(Units.KILOMETERS);
+		assertEquals(Units.KILOMETERS, mwv.getSpeedUnit());
 	}
 
 	/**

--- a/src/test/java/net/sf/marineapi/nmea/parser/OSDTest.java
+++ b/src/test/java/net/sf/marineapi/nmea/parser/OSDTest.java
@@ -1,0 +1,235 @@
+/* 
+ * OSDTest.java
+ * Copyright (C) 2020 Joshua Sweaney
+ * 
+ * This file is part of Java Marine API.
+ * <http://ktuukkan.github.io/marine-api/>
+ * 
+ * Java Marine API is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * 
+ * Java Marine API is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java Marine API. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.sf.marineapi.nmea.parser;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.sf.marineapi.nmea.sentence.OSDSentence;
+import net.sf.marineapi.nmea.sentence.TalkerId;
+import net.sf.marineapi.nmea.util.DataStatus;
+import net.sf.marineapi.nmea.util.ReferenceSystem;
+import net.sf.marineapi.nmea.util.Units;
+
+/**
+ * OSDTest
+ * 
+ * @author Joshua Sweaney
+ */
+public class OSDTest {
+
+    public static final String EXAMPLE = "$RAOSD,35.1,A,36.0,P,10.2,P,15.3,0.1,N*41";
+    public OSDSentence example, empty;
+
+    @Before
+    public void setUp() {
+        example = new OSDParser(EXAMPLE);
+        empty = new OSDParser(TalkerId.RA);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#getHeading()}.
+     */
+    @Test
+    public void testGetHeading() {
+        assertEquals(35.1, example.getHeading(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#getHeadingStatus()}.
+     */
+    @Test
+    public void testGetHeadingStatus() {
+        assertEquals(DataStatus.ACTIVE, example.getHeadingStatus());
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#getCourse()}.
+     */
+    @Test
+    public void testGetCourse() {
+        assertEquals(36.0, example.getCourse(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#getCourseReference()}.
+     */
+    @Test
+    public void testGetCourseReference() {
+        assertEquals(ReferenceSystem.POSITIONING_SYSTEM_GROUND_REFERENCE,
+                        example.getCourseReference());
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#getSpeed()}.
+     */
+    @Test
+    public void testGetSpeed() {
+        assertEquals(10.2, example.getSpeed(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#getSpeedReference()}.
+     */
+    @Test
+    public void testGetSpeedReference() {
+        assertEquals(ReferenceSystem.POSITIONING_SYSTEM_GROUND_REFERENCE,
+                        example.getSpeedReference());
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#getVesselSet()}.
+     */
+    @Test
+    public void testGetVesselSet() {
+        assertEquals(15.3, example.getVesselSet(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#getVesselDrift()}.
+     */
+    @Test
+    public void testGetVesselDrift() {
+        assertEquals(0.1, example.getVesselDrift(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#getSpeedUnits()}.
+     */
+    @Test
+    public void testGetSpeedUnits() {
+        assertEquals(Units.NAUTICAL_MILES, example.getSpeedUnits());
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#setHeading(double)}.
+     */
+    @Test
+    public void testSetHeading() {
+        double newHeading = 275.2;
+        empty.setHeading(newHeading);
+        assertEquals(newHeading, empty.getHeading(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#setHeadingStatus(DataStatus)}.
+     */
+    @Test
+    public void testSetHeadingStatus() {
+        DataStatus newStatus = DataStatus.VOID;
+        empty.setHeadingStatus(newStatus);
+        assertEquals(newStatus, empty.getHeadingStatus());
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#setCourse(double)}.
+     */
+    @Test
+    public void testSetCourse() {
+        double newCourse = 95.3;
+        empty.setCourse(newCourse);
+        assertEquals(newCourse, empty.getCourse(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#setCourseReference(ReferenceSystem)}.
+     */
+    @Test
+    public void testSetCourseReference() {
+        ReferenceSystem newReference = ReferenceSystem.BOTTOM_TRACKING_LOG;
+        empty.setCourseReference(newReference);
+        assertEquals(newReference, empty.getCourseReference());
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#setSpeed(double)}.
+     */
+    @Test
+    public void testSetSpeed() {
+        double newSpeed = 11.2;
+        empty.setSpeed(newSpeed);
+        assertEquals(newSpeed, empty.getSpeed(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#setSpeedReference(ReferenceSystem)}.
+     */
+    @Test
+    public void testSetSpeedReference() {
+        ReferenceSystem newReference = ReferenceSystem.RADAR_TRACKING;
+        empty.setSpeedReference(newReference);
+        assertEquals(newReference, empty.getSpeedReference());
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#setVesselSet(double)}.
+     */
+    @Test
+    public void testSetVesselSet() {
+        double newSet = 13.9;
+        empty.setVesselSet(newSet);
+        assertEquals(newSet, empty.getVesselSet(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#setVesselDrift(double)}.
+     */
+    @Test
+    public void testSetVesselDrift() {
+        double newDrift = 365.4;
+        empty.setVesselDrift(newDrift);
+        assertEquals(newDrift, empty.getVesselDrift(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.OSDParser#setSpeedUnits(Units)}.
+     */
+    @Test (expected = IllegalArgumentException.class)
+    public void testSetSpeedUnits() {
+        Units newUnits = Units.NAUTICAL_MILES;
+        empty.setSpeedUnits(newUnits);
+        assertEquals(newUnits, empty.getSpeedUnits());
+
+        // An invalid speed unit. Should throw IllegalArgumentException.
+        empty.setSpeedUnits(Units.CELSIUS);
+    }
+
+    
+}

--- a/src/test/java/net/sf/marineapi/nmea/parser/RSDTest.java
+++ b/src/test/java/net/sf/marineapi/nmea/parser/RSDTest.java
@@ -1,0 +1,312 @@
+/* 
+ * RSDTest.java
+ * Copyright (C) 2020 Joshua Sweaney
+ * 
+ * This file is part of Java Marine API.
+ * <http://ktuukkan.github.io/marine-api/>
+ * 
+ * Java Marine API is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * 
+ * Java Marine API is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java Marine API. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.sf.marineapi.nmea.parser;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.sf.marineapi.nmea.sentence.RSDSentence;
+import net.sf.marineapi.nmea.sentence.TalkerId;
+import net.sf.marineapi.nmea.util.DisplayRotation;
+import net.sf.marineapi.nmea.util.Units;
+
+/**
+ * RSDTest
+ * 
+ * @author Joshua Sweaney
+ */
+public class RSDTest {
+
+    public static final String EXAMPLE = "$RARSD,12,90,24,45,6,270,12,315,6.5,118,96,N,N*5A";
+    public RSDSentence example, empty;
+
+    @Before
+    public void setUp() {
+        example = new RSDParser(EXAMPLE);
+        empty = new RSDParser(TalkerId.RA);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#getOriginOneRange()}.
+     */
+    @Test
+    public void testGetOriginOneRange() {
+        assertEquals(12.0, example.getOriginOneRange(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#getOriginOneBearing()}.
+     */
+    @Test
+    public void testGetOriginOneBearing() {
+        assertEquals(90.0, example.getOriginOneBearing(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#getVRMOneRange()}.
+     */
+    @Test
+    public void testGetVRMOneRange() {
+        assertEquals(24.0, example.getVRMOneRange(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#getEBLOneBearing()}.
+     */
+    @Test
+    public void testGetEBLOneBearing() {
+        assertEquals(45.0, example.getEBLOneBearing(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#getOriginTwoRange()}.
+     */
+    @Test
+    public void testGetOriginTwoRange() {
+        assertEquals(6.0, example.getOriginTwoRange(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#getOriginTwoBearing()}.
+     */
+    @Test
+    public void testGetOriginTwoBearing() {
+        assertEquals(270.0, example.getOriginTwoBearing(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#getVRMTwoRange()}.
+     */
+    @Test
+    public void testGetVRMTwoRange() {
+        assertEquals(12.0, example.getVRMTwoRange(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#getEBLTwoBearing()}.
+     */
+    @Test
+    public void testGetEBLTwoBearing() {
+        assertEquals(315.0, example.getEBLTwoBearing(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#getCursorRange()}.
+     */
+    @Test
+    public void testGetCursorRange() {
+        assertEquals(6.5, example.getCursorRange(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#getCursorBearing()}.
+     */
+    @Test
+    public void testGetCursorBearing() {
+        assertEquals(118.0, example.getCursorBearing(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#getRangeScale()}.
+     */
+    @Test
+    public void testGetRangeScale() {
+        assertEquals(96.0, example.getRangeScale(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#getRangeUnits()}.
+     */
+    @Test
+    public void testGetRangeUnits() {
+        assertEquals(Units.NAUTICAL_MILES, example.getRangeUnits());
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#getDisplayRotation()}.
+     */
+    @Test
+    public void testGetDisplayRotation() {
+        assertEquals(DisplayRotation.NORTH_UP, example.getDisplayRotation());
+    }
+    
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#setOriginOneRange(double)}.
+     */
+    @Test
+    public void testSetOriginOneRange() {
+        double newRange = 0.75;
+        empty.setOriginOneRange(newRange);
+        assertEquals(newRange, empty.getOriginOneRange(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#setOriginOneBearing(double)}.
+     */
+    @Test
+    public void testSetOriginOneBearing() {
+        double newBearing = 93.2;
+        empty.setOriginOneBearing(newBearing);
+        assertEquals(newBearing, empty.getOriginOneBearing(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#setVRMOneRange(double)}.
+     */
+    @Test
+    public void testSetVRMOneRange() {
+        double newRange = 12.5;
+        empty.setVRMOneRange(newRange);
+        assertEquals(newRange, empty.getVRMOneRange(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#setEBLOneBearing(double)}.
+     */
+    @Test
+    public void testSetEBLOneBearing() {
+        double newBearing = 147.0;
+        empty.setEBLOneBearing(newBearing);
+        assertEquals(newBearing, empty.getEBLOneBearing(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#setOriginTwoRange(double)}.
+     */
+    @Test
+    public void testSetOriginTwoRange() {
+        double newRange = 0.75;
+        empty.setOriginTwoRange(newRange);
+        assertEquals(newRange, empty.getOriginTwoRange(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#setOriginTwoBearing(double)}.
+     */
+    @Test
+    public void testSetOriginTwoBearing() {
+        double newBearing = 93.2;
+        empty.setOriginTwoBearing(newBearing);
+        assertEquals(newBearing, empty.getOriginTwoBearing(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#setVRMTwoRange(double)}.
+     */
+    @Test
+    public void testSetVRMTwoRange() {
+        double newRange = 12.5;
+        empty.setVRMTwoRange(newRange);
+        assertEquals(newRange, empty.getVRMTwoRange(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#setEBLTwoBearing(double)}.
+     */
+    @Test
+    public void testSetEBLTwoBearing() {
+        double newBearing = 147.0;
+        empty.setEBLTwoBearing(newBearing);
+        assertEquals(newBearing, empty.getEBLTwoBearing(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#setCursorRange(double)}.
+     */
+    @Test
+    public void testSetCursorRange() {
+        double newRange = 48.32;
+        empty.setCursorRange(newRange);
+        assertEquals(newRange, empty.getCursorRange(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#setCursorBearing(double)}.
+     */
+    @Test
+    public void testSetCursorBearing() {
+        double newBearing = 300.4;
+        empty.setCursorBearing(newBearing);
+        assertEquals(newBearing, empty.getCursorBearing(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#setRangeScale(double)}.
+     */
+    @Test
+    public void testSetRangeScale() {
+        double newScale = 0.75;
+        empty.setRangeScale(newScale);
+        assertEquals(newScale, empty.getRangeScale(), 0.0);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#setRangeUnits(Units)}.
+     */
+    @Test (expected = IllegalArgumentException.class)
+    public void testSetRangeUnits() {
+        Units newUnits = Units.KILOMETERS;
+        empty.setRangeUnits(newUnits);
+        assertEquals(newUnits, empty.getRangeUnits());
+
+        // Invalid range unit. Should throw IllegalArgumentException
+        Units invalidUnits = Units.FATHOMS;
+        empty.setRangeUnits(invalidUnits);
+    }
+
+    /**
+     * Test for
+     * {@link net.sf.marineapi.nmea.parser.RSDParser#setDisplayRotation(DisplayRotation)}.
+     */
+    @Test
+    public void testSetDisplayRotation() {
+        DisplayRotation newRotation = DisplayRotation.COURSE_UP;
+        empty.setDisplayRotation(newRotation);
+        assertEquals(newRotation, empty.getDisplayRotation());
+    }
+
+}

--- a/src/test/java/net/sf/marineapi/nmea/parser/TLBTest.java
+++ b/src/test/java/net/sf/marineapi/nmea/parser/TLBTest.java
@@ -1,0 +1,115 @@
+/* 
+ * TLBTest.java
+ * Copyright (C) 2020 Joshua Sweaney
+ * 
+ * This file is part of Java Marine API.
+ * <http://ktuukkan.github.io/marine-api/>
+ * 
+ * Java Marine API is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * 
+ * Java Marine API is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java Marine API. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.sf.marineapi.nmea.parser;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.sf.marineapi.nmea.sentence.TLBSentence;
+import net.sf.marineapi.nmea.sentence.TalkerId;
+
+/**
+ * TLBTest
+ * 
+ * @author Joshua Sweaney
+ */
+public class TLBTest {
+
+    public static final String EXAMPLE = "$RATLB,1,SHIPONE,2,SHIPTWO,3,SHIPTHREE*3D";
+
+    private TLBSentence empty, threeTargets;
+
+    @Before
+    public void setUp() {
+        empty = new TLBParser(TalkerId.RA);
+        threeTargets = new TLBParser(EXAMPLE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTLBParser() {
+        // Target 5 has odd number of fields (missing lable for target 5). This should throw an exception on construct.
+        new TLBParser("$RATLB,3,SHIPTHREE,5*2F"); 
+    }
+
+    /**
+	 * Test method for
+	 * {@link net.sf.marineapi.nmea.parser.TLBParser#addTargetLabel(int, String)}.
+	 */
+    @Test
+    public void testAddTargetLabel() {
+        empty.addTargetLabel(3, "SHIPTHREE");
+        assertTrue(empty.toString().contains("3,SHIPTHREE*"));
+        empty.addTargetLabel(5,"SHIPFIVE");
+        assertTrue(empty.toString().contains("3,SHIPTHREE,5,SHIPFIVE*")); // SHIPFIVE is now at the end
+        empty.addTargetLabel(99, "SHIP99");
+        assertTrue(empty.toString().contains("3,SHIPTHREE,5,SHIPFIVE,99,SHIP99*"));
+
+        // Adding to existing sentence
+        threeTargets.addTargetLabel(4, "SHIPFOUR");
+        assertTrue(threeTargets.toString().contains("1,SHIPONE,2,SHIPTWO,3,SHIPTHREE,4,SHIPFOUR*"));
+    }
+
+    /**
+	 * Test method for
+	 * {@link net.sf.marineapi.nmea.parser.TLBParser#setTargetPairs(int, String)}.
+	 */
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetTargetPairs() {
+        int[] ids = {1,2,3};
+        String[] labels = {"SHIPONE", "SHIPTWO", "SHIPTHREE"};
+        empty.setTargetPairs(ids, labels);
+
+        assertTrue(empty.toString().contains("1,SHIPONE,2,SHIPTWO,3,SHIPTHREE*"));
+
+        int[] ids_two = {5,6};
+        String[] labels_two = {"SHIPFIVE", "SHIPSIX", "SHIPSEVEN"}; // Intentionally larger than ids_two[]
+        empty.setTargetPairs(ids_two, labels_two); // Will throw exception
+    }
+
+    /**
+	 * Test method for
+	 * {@link net.sf.marineapi.nmea.parser.TLBParser#getTargetIds()}.
+	 */
+    @Test
+    public void testGetTargetIds() {
+        int[] ids = {1,2,3};
+        assertArrayEquals(ids, threeTargets.getTargetIds());
+        
+        int[] ids_empty = {};
+        assertArrayEquals(ids_empty, empty.getTargetIds());
+    }
+
+    /**
+	 * Test method for
+	 * {@link net.sf.marineapi.nmea.parser.TLBParser#getTargetLabels()}.
+	 */
+    @Test
+    public void testGetTargetLabels() {
+        String[] labels = {"SHIPONE", "SHIPTWO", "SHIPTHREE"};
+        assertArrayEquals(labels, threeTargets.getTargetLabels());
+
+        String[] labels_empty = {};
+        assertArrayEquals(labels_empty, empty.getTargetLabels());
+    }
+    
+}


### PR DESCRIPTION
I have added TLB, OSD, and RSD sentences and parsers (and updated readme/changelog as appropriate), along with tests for each. Also added ReferenceSystem and DisplayRotation enums for the new sentences that need them.

The reason for updating some of the units, is that the same character (e.g. 'K') that was used for "kilometers per hour", is used as a measure of distance in some sentences, such as RSD. I think it is better if the Units enum uses base units (e.g. kilometers, or nautical miles) rather than kilometers-per-hour, and knots. This allows them to be used more generally, and the meaning is still clear (e.g. nautical miles is obviously knots in the context of speed).

I have also made a change that allows empty sentences (when only a TalkerID is passed to the SentenceParser) to contain 0 fields. This is because the TLB sentence *only* contains pairs of target numbers and target labels. If none have been added, then the sentence contains 0 other fields. When initiating an empty TLB sentence, it is necessary to have 0 fields currently present. All tests continue to pass after this change.