### PR TITLE
fix(AIS): On position report type B, fix longitude availability check

### DIFF
--- a/src/main/java/net/sf/marineapi/ais/parser/AISPositionReportBParser.java
+++ b/src/main/java/net/sf/marineapi/ais/parser/AISPositionReportBParser.java
@@ -149,7 +149,7 @@ class AISPositionReportBParser extends AISMessageParser implements AISPositionRe
 
 	@Override
 	public boolean hasLongitude() {
-		return Latitude27.isAvailable(fLongitude);
+		return Longitude28.isAvailable(fLongitude);
 	}
 
 	@Override


### PR DESCRIPTION
By looking at the code, I've found this slight mistake.

I've not added unit test, because I don't know how to forge an AISVDM string. I could add it / update existing one if someone can help me forge a message that would contain a longitude whose value is more than 90 or less than -90. 