### PR TITLE
Nav Status added to RMC sentence. This field comes from NMEA 4.1.

### DIFF
--- a/src/main/java/net/sf/marineapi/nmea/parser/RMCParser.java
+++ b/src/main/java/net/sf/marineapi/nmea/parser/RMCParser.java
@@ -29,6 +29,7 @@ import net.sf.marineapi.nmea.util.Date;
 import net.sf.marineapi.nmea.util.FaaMode;
 import net.sf.marineapi.nmea.util.Position;
 import net.sf.marineapi.nmea.util.Time;
+import net.sf.marineapi.nmea.util.NavStatus;
 
 /**
  * RMC sentence parser.
@@ -49,6 +50,7 @@ class RMCParser extends PositionParser implements RMCSentence {
 	private static final int MAG_VARIATION = 9;
 	private static final int VAR_HEMISPHERE = 10;
 	private static final int MODE = 11;
+	private static final int NAV_STATUS = 12;
 
 	/**
 	 * Creates a new instance of RMCParser.
@@ -61,12 +63,12 @@ class RMCParser extends PositionParser implements RMCSentence {
 	}
 
 	/**
-	 * Creates a ZDA parser with empty sentence.
+	 * Creates a RMC parser with empty sentence.
 	 *
 	 * @param talker TalkerId to set
 	 */
 	public RMCParser(TalkerId talker) {
-		super(talker, SentenceId.RMC, 12);
+		super(talker, SentenceId.RMC, 13);
 	}
 
 	/*
@@ -108,6 +110,12 @@ class RMCParser extends PositionParser implements RMCSentence {
 	public FaaMode getMode() {
 		return FaaMode.valueOf(getCharValue(MODE));
 	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 */
+	public NavStatus getNavStatus() { return NavStatus.valueOf(getCharValue(NAV_STATUS)); }
 
 	/*
 	 * (non-Javadoc)
@@ -181,7 +189,7 @@ class RMCParser extends PositionParser implements RMCSentence {
 	public void setDirectionOfVariation(CompassPoint dir) {
 		if (dir != CompassPoint.EAST && dir != CompassPoint.WEST) {
 			throw new IllegalArgumentException(
-				"Invalid variation direction, expected EAST or WEST.");
+					"Invalid variation direction, expected EAST or WEST.");
 		}
 		setCharValue(VAR_HEMISPHERE, dir.toChar());
 	}
@@ -195,6 +203,16 @@ class RMCParser extends PositionParser implements RMCSentence {
 	public void setMode(FaaMode mode) {
 		setFieldCount(12);
 		setCharValue(MODE, mode.toChar());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 */
+	@Override
+	public void setNavStatus(NavStatus navStatus) {
+		setFieldCount(13);
+		setCharValue(NAV_STATUS, navStatus.toChar());
 	}
 
 	/*

--- a/src/main/java/net/sf/marineapi/nmea/sentence/RMCSentence.java
+++ b/src/main/java/net/sf/marineapi/nmea/sentence/RMCSentence.java
@@ -23,6 +23,7 @@ package net.sf.marineapi.nmea.sentence;
 import net.sf.marineapi.nmea.util.CompassPoint;
 import net.sf.marineapi.nmea.util.DataStatus;
 import net.sf.marineapi.nmea.util.FaaMode;
+import net.sf.marineapi.nmea.util.NavStatus;
 
 /**
  * Recommended minimum navigation information type C. Current time and date,
@@ -85,6 +86,13 @@ public interface RMCSentence extends PositionSentence, TimeSentence,
 	FaaMode getMode();
 
 	/**
+	 * Get the Navigation Status.
+	 *
+	 * @return NavStatus enum
+	 */
+	NavStatus getNavStatus();
+
+	/**
 	 * Get current speed over ground (SOG).
 	 * 
 	 * @return Speed in knots (nautical miles per hour).
@@ -141,6 +149,13 @@ public interface RMCSentence extends PositionSentence, TimeSentence,
 	 * @param mode FaaMode enum to set
 	 */
 	void setMode(FaaMode mode);
+
+	/**
+	 * Set the Navigation Status.
+	 *
+	 * @param navStatus NavStatus enum to set
+	 */
+	void setNavStatus(NavStatus navStatus);
 
 	/**
 	 * Set current speed over ground (SOG).

--- a/src/main/java/net/sf/marineapi/nmea/util/NavStatus.java
+++ b/src/main/java/net/sf/marineapi/nmea/util/NavStatus.java
@@ -17,7 +17,7 @@ public enum NavStatus {
     ESTIMATED('E'),
 
     /** Navigation status is Manual. */
-    MANUEL('M'),
+    MANUAL('M'),
 
     /** Navigation status is Not valid. */
     NOT_VALID('N'),

--- a/src/main/java/net/sf/marineapi/nmea/util/NavStatus.java
+++ b/src/main/java/net/sf/marineapi/nmea/util/NavStatus.java
@@ -1,0 +1,61 @@
+package net.sf.marineapi.nmea.util;
+
+/**
+ * <p>FAA operating modes reported by  RMC sentences since NMEA 4.1. </p>
+ * @author John
+ */
+
+public enum NavStatus {
+
+    /** Navigation status is autonomous. */
+    AUTONOMOUS('A'),
+
+    /** Navigation status is differential. */
+    DIFFERENTIAL('D'),
+
+    /** Navigation status is Estimated. */
+    ESTIMATED('E'),
+
+    /** Navigation status is Manual. */
+    MANUEL('M'),
+
+    /** Navigation status is Not valid. */
+    NOT_VALID('N'),
+
+    /** Navigation status is Simulator. */
+    SIMULATOR('S'),
+
+    /** Navigation status is Valid. */
+    VALID('V');
+
+    private final char navStatus;
+
+    NavStatus(char navStatusCh) {
+        navStatus = navStatusCh;
+    }
+
+    /**
+     * Returns the corresponding char indicator of Navigation Status.
+     *
+     * @return NavStatus char used in sentences.
+     */
+    public char toChar() {
+        return navStatus;
+    }
+
+    /**
+     * Returns the NavStatus enum corresponding the actual char indicator used in
+     * the sentencess.
+     *
+     * @param ch Char mode indicator
+     * @return NavStatus enum
+     */
+    public static NavStatus valueOf(char ch) {
+        for (NavStatus gm : values()) {
+            if (gm.toChar() == ch) {
+                return gm;
+            }
+        }
+        return valueOf(String.valueOf(ch));
+    }
+}

--- a/src/test/java/net/sf/marineapi/nmea/parser/ChecksumTest.java
+++ b/src/test/java/net/sf/marineapi/nmea/parser/ChecksumTest.java
@@ -78,7 +78,7 @@ public class ChecksumTest {
 		assertEquals("1D", Checksum.calculate(BODTest.EXAMPLE));
 		assertEquals("63", Checksum.calculate(GGATest.EXAMPLE));
 		assertEquals("26", Checksum.calculate(GLLTest.EXAMPLE));
-		assertEquals("0B", Checksum.calculate(RMCTest.EXAMPLE));
+		assertEquals("74", Checksum.calculate(RMCTest.EXAMPLE));
 		assertEquals("3D", Checksum.calculate(GSATest.EXAMPLE));
 		assertEquals("73", Checksum.calculate(GSVTest.EXAMPLE));
 		assertEquals("58", Checksum.calculate(RMBTest.EXAMPLE));

--- a/src/test/java/net/sf/marineapi/nmea/parser/RMCTest.java
+++ b/src/test/java/net/sf/marineapi/nmea/parser/RMCTest.java
@@ -27,7 +27,7 @@ public class RMCTest {
 	public static final String EXAMPLE = "$GPRMC,120044.567,A,6011.552,N,02501.941,E,000.0,360.0,160705,006.1,E,A,S*74";
 
 	/** Example of legacy format (short by one field) */
-	public static final String EXAMPLE_LEGACY = "$GPRMC,183729,A,3907.356,N,12102.482,W,000.0,360.0,080301,015.5,E*6F";
+	public static final String EXAMPLE_LEGACY = "$GPRMC,183729,A,3907.356,N,12102.482,W,000.0,360.0,080301,015.5,E,S*10";
 
 	RMCParser empty;
 	RMCParser rmc;
@@ -47,7 +47,7 @@ public class RMCTest {
 	@Test
 	public void testConstructor() {
 		assertEquals(13, empty.getFieldCount());
-		assertEquals(11, legacy.getFieldCount());
+		assertEquals(12, legacy.getFieldCount());
 	}
 
 	/**
@@ -268,8 +268,8 @@ public class RMCTest {
 	 */
 	@Test
 	public void testSetNavStatus() {
-		rmc.setNavStatus(NavStatus.MANUEL);
-		assertEquals(NavStatus.MANUEL, rmc.getNavStatus());
+		rmc.setNavStatus(NavStatus.MANUAL);
+		assertEquals(NavStatus.MANUAL, rmc.getNavStatus());
 		rmc.setNavStatus(NavStatus.AUTONOMOUS);
 		assertEquals(NavStatus.AUTONOMOUS, rmc.getNavStatus());
 		rmc.setNavStatus(NavStatus.DIFFERENTIAL);

--- a/src/test/java/net/sf/marineapi/nmea/parser/RMCTest.java
+++ b/src/test/java/net/sf/marineapi/nmea/parser/RMCTest.java
@@ -11,6 +11,7 @@ import net.sf.marineapi.nmea.util.Date;
 import net.sf.marineapi.nmea.util.FaaMode;
 import net.sf.marineapi.nmea.util.Position;
 import net.sf.marineapi.nmea.util.Time;
+import net.sf.marineapi.nmea.util.NavStatus;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -23,7 +24,7 @@ import org.junit.Test;
 public class RMCTest {
 
 	/** Example sentence */
-	public static final String EXAMPLE = "$GPRMC,120044.567,A,6011.552,N,02501.941,E,000.0,360.0,160705,006.1,E,A*0B";
+	public static final String EXAMPLE = "$GPRMC,120044.567,A,6011.552,N,02501.941,E,000.0,360.0,160705,006.1,E,A,S*74";
 
 	/** Example of legacy format (short by one field) */
 	public static final String EXAMPLE_LEGACY = "$GPRMC,183729,A,3907.356,N,12102.482,W,000.0,360.0,080301,015.5,E*6F";
@@ -45,7 +46,7 @@ public class RMCTest {
 
 	@Test
 	public void testConstructor() {
-		assertEquals(12, empty.getFieldCount());
+		assertEquals(13, empty.getFieldCount());
 		assertEquals(11, legacy.getFieldCount());
 	}
 
@@ -112,6 +113,14 @@ public class RMCTest {
 	@Test
 	public void testGetFaaMode() {
 		assertEquals(FaaMode.AUTOMATIC, rmc.getMode());
+	}
+
+	/**
+	 * Test method for {@link RMCParser#getNavStatus()}.
+	 */
+	@Test
+	public void  testGetNavStatus() {
+		assertEquals(NavStatus.SIMULATOR, rmc.getNavStatus());
 	}
 
 	/**
@@ -251,6 +260,28 @@ public class RMCTest {
 		assertEquals(FaaMode.SIMULATED, rmc.getMode());
 		rmc.setMode(FaaMode.ESTIMATED);
 		assertEquals(FaaMode.ESTIMATED, rmc.getMode());
+	}
+
+	/**
+	 * Test method for
+	 * {@link net.sf.marineapi.nmea.parser.RMCParser#setNavStatus(NavStatus)}.
+	 */
+	@Test
+	public void testSetNavStatus() {
+		rmc.setNavStatus(NavStatus.MANUEL);
+		assertEquals(NavStatus.MANUEL, rmc.getNavStatus());
+		rmc.setNavStatus(NavStatus.AUTONOMOUS);
+		assertEquals(NavStatus.AUTONOMOUS, rmc.getNavStatus());
+		rmc.setNavStatus(NavStatus.DIFFERENTIAL);
+		assertEquals(NavStatus.DIFFERENTIAL, rmc.getNavStatus());
+		rmc.setNavStatus(NavStatus.NOT_VALID);
+		assertEquals(NavStatus.NOT_VALID, rmc.getNavStatus());
+		rmc.setNavStatus(NavStatus.ESTIMATED);
+		assertEquals(NavStatus.ESTIMATED, rmc.getNavStatus());
+		rmc.setNavStatus(NavStatus.VALID);
+		assertEquals(NavStatus.VALID, rmc.getNavStatus());
+		rmc.setNavStatus(NavStatus.SIMULATOR);
+		assertEquals(NavStatus.SIMULATOR, rmc.getNavStatus());
 	}
 
 	/**

--- a/src/test/java/net/sf/marineapi/nmea/parser/SentenceParserTest.java
+++ b/src/test/java/net/sf/marineapi/nmea/parser/SentenceParserTest.java
@@ -331,7 +331,7 @@ public class SentenceParserTest {
 			String val = instance.getStringValue(0);
 			assertEquals("120044.567", val);
 			val = instance.getStringValue(instance.getFieldCount() - 1);
-			assertEquals("A", val);
+			assertEquals("S", val);
 		} catch (IndexOutOfBoundsException e) {
 			fail("Unexpected IndexOutOfBoundsException");
 		} catch (Exception e) {


### PR DESCRIPTION
There is an update  in RMC(Recommended Minimum Navigation Information) sentence. RMC sentence has extended with NavStatus field in NMEA 4.1. Parser and Sentence of RMC sentence updated according to NMEA 4.1.


(https://gpsd.gitlab.io/gpsd/NMEA.html#_rmc_recommended_minimum_navigation_information)